### PR TITLE
[Issue #27] Add templates for email and tweets

### DIFF
--- a/Template-Email-SpeakerDayBefore.md
+++ b/Template-Email-SpeakerDayBefore.md
@@ -1,0 +1,21 @@
+<!-- NOTE: this is a template, please edit a copy before pasting into email :)  -->
+Dear [Speaker name],
+
+We're thrilled you're going to be presenting at tomorrow's JavaScript.MN Meetup. We wanted to reach out again ahead of tomorrow's event with a little more on the logistics.
+
+Arrival: Feel free to arrive at the venue any time between 5:30 and 6pm. [Organizer(s) chosen for speaker contact] will be on site to make sure you get in and help you get set up.
+
+A/V: The venue, WeWork, provides HDMI and a mic for the room. We have MiniDisplayPort-to-HDMI, Lightning-to-HDMI, and USB-C-to-HDMI adapters available for you to use. We also livestream and record our talks, which end up on the YouTube page for our group. Let us know if you have questions about this or would prefer not to have the talk streamed/recorded.
+
+Schedule:
+
+- [Organizers] will be coordinating the schedule for the event. We'll kick things off with announcements at or slightly after 6:30.
+  <!-- This part is dependent on whether we have scheduled lightning talks, or whether we have 2 main speakers, etc. -->
+- <!-- no scheduled lightning talks --> At this event, we don't have any scheduled lightning talks, so after announcements complete we may invite folks from the group to give a short 5 to 10 minute talk. If anyone takes us up on that, we'll let them present, have a quick break, and get you settled for your presentation.
+- <!-- scheduled lightning talks --> There will be some short lightning talks prior to the main presentation(s).
+- <!-- if they are first or sole speaker --> We plan for you to start your presentation around 7pm.
+- <!-- if they are the second... speaker --> [Other speaker] will start at 7pm, and you'll be giving your talk at 7:30pm.
+
+Code of Conduct: We ask our speakers review the [code of conduct](https://javascriptmn.com/code-of-conduct/) for our event prior to presenting. It's important to us that speakers, organizers, and attendees all work together to create a harassment-free environment. Let us know if you have any questions.
+
+Contact: If at any point you need help before or during the event, you can reach out directly to [Organizers]. If you can't track us down, you can text this number, which goes to all of us: 651-383-1147

--- a/Template-Email-SpeakerDayBefore.md
+++ b/Template-Email-SpeakerDayBefore.md
@@ -1,7 +1,7 @@
 <!-- NOTE: this is a template, please edit a copy before pasting into email :)  -->
 Dear [Speaker name],
 
-We're thrilled you're going to be presenting at tomorrow's JavaScript.MN Meetup. We wanted to reach out again ahead of tomorrow's event with a little more on the logistics.
+We're thrilled you're going to be presenting at tomorrow's JavaScript Minnesota Meetup. We wanted to reach out again ahead of tomorrow's event with a little more on the logistics.
 
 Arrival: Feel free to arrive at the venue any time between 5:30 and 6pm. [Organizer(s) chosen for speaker contact] will be on site to make sure you get in and help you get set up.
 

--- a/Template-Tweet-DayBefore.md
+++ b/Template-Tweet-DayBefore.md
@@ -1,0 +1,1 @@
+Our [Month] event is tomorrow! Head over to WeWork in Uptown for [Speaker twitter]'s talk on [Talk title]. Join the waitlist or update your RSVP! [meetup.com event link]

--- a/Template-Tweet-StartOfMeetup.txt
+++ b/Template-Tweet-StartOfMeetup.txt
@@ -1,0 +1,1 @@
+We're live with [Speaker (twitter)] on [Title]! Tune in: [youtube livestream link]


### PR DESCRIPTION
Addresses #27 

- email to speaker, the day before the event
- tweet for day before
- tweet for start of meetup

## todo's

- [x] are there other tweets that need templates? 